### PR TITLE
Fix css issue of overlaping buttons

### DIFF
--- a/app/views/translation_assignments/_translation_file.html.erb
+++ b/app/views/translation_assignments/_translation_file.html.erb
@@ -37,15 +37,13 @@
         <button class="bg-blue-500 group-hover:bg-blue-700 text-white font-bold py-2 px-4 w-full rounded-full">
           select file
         </button>
-        <div class="absolute top-0 left-0 w-full h-full cursor-pointer">
-          <%= form.file_field :file,
-                              class: "opacity-0 w-full h-full",
-                              multiple: true,
-                              data: { target: "file-input.input", action: "file-input#display" } %>
-        </div>
+        <%= form.file_field :file,
+                            class: "absolute block opacity-0 top-0 right-0",
+                            multiple: true,
+                            data: { target: "file-input.input", action: "file-input#display" } %>
       </div>
       <%= form.submit 'Submit',
-                      class: "cursor-pointer hidden ml-2 text-xs bg-pink-500 hover:bg-pink-700 text-white font-bold py-2 px-4 rounded-full",
+                      class: "cursor-pointer hidden ml-2 text-xs bg-pink-500 hover:bg-pink-700 text-white font-bold py-2 px-4 rounded-full z-50",
                       data: { target: "file-input.submit" } %>
     <% end %>
     <span class="text-xs text-red-500 mr-2"><%= translation_file.errors.full_messages.to_sentence if translation_file.errors.any? %></span>


### PR DESCRIPTION
<img width="607" alt="Bildschirmfoto 2021-01-14 um 13 39 24" src="https://user-images.githubusercontent.com/777729/104592081-f2364900-566d-11eb-94f5-8e065881ccd2.png">
The invisible file input was overlapping the submit button when the selected filename is too long.