### PR TITLE
Rename WorkerInvitationFilter to WorkerFilter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'carrierwave'
 
 gem 'state_machines-activerecord'
 
-gem 'cirro-ruby-client', '~> 1.2.2'
+gem 'cirro-ruby-client', '~> 1.3.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,10 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
     childprocess (3.0.0)
-    cirro-ruby-client (1.2.2)
+    cirro-ruby-client (1.3.0)
+      faraday (< 1.2.0)
       faraday_middleware
-      json_api_client
+      json_api_client (>= 1.10.0)
       jwt
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -327,7 +328,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   carrierwave
-  cirro-ruby-client (~> 1.2.2)
+  cirro-ruby-client (~> 1.3.0)
   config
   devise
   jbuilder (~> 2.7)

--- a/app/models/translation_assignment.rb
+++ b/app/models/translation_assignment.rb
@@ -63,7 +63,7 @@ class TranslationAssignment < ApplicationRecord
 
   def create_gig_with_tasks_and_invitation_filter
     price_per_translation_result = 500
-    worker_invitation_filter = CirroIO::Client::WorkerInvitationFilter.new(filter_query: %Q({ "languages": { "$in": ["#{from_language}", "#{to_language}"] }, "domains": { "$in": ["#{domain}"] } }))
+    worker_filter = CirroIO::Client::WorkerFilter.new(filter_query: %Q({ "languages": { "$in": ["#{from_language}", "#{to_language}"] }, "domains": { "$in": ["#{domain}"] } }))
     task = CirroIO::Client::GigTask.new(title: self.class.name, base_price: price_per_translation_result)
 
     gig = CirroIO::Client::Gig.new(title: title,
@@ -74,7 +74,7 @@ class TranslationAssignment < ApplicationRecord
                                    url: Rails.application.routes.url_helpers.translation_assignment_url(id, host: Settings.host)
                                   )
 
-    created_gig = gig.bulk_create_with(worker_invitation_filter, [task])
+    created_gig = gig.bulk_create_with(worker_filter, [task])
 
     update_attribute(:gig_idx, created_gig.id)
   end


### PR DESCRIPTION
You can see that no other references to WorkerInvitationFilter exist in this repo via this search: https://github.com/test-IO/example-cirro-rails-app/search?q=invitation